### PR TITLE
[CAZB-1868] Add support for storing Cognito credentials in Secrets Manager

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'activerecord-nulldb-adapter'
 gem 'aws-sdk-cognitoidentityprovider'
 gem 'aws-sdk-rails'
 gem 'aws-sdk-s3'
+gem 'aws-sdk-secretsmanager'
 gem 'bootsnap', require: false
 gem 'devise'
 gem 'haml'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,9 @@ GEM
       aws-sdk-core (~> 3, >= 3.83.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.1)
+    aws-sdk-secretsmanager (1.36.0)
+      aws-sdk-core (~> 3, >= 3.71.0)
+      aws-sigv4 (~> 1.1)
     aws-sdk-ses (1.28.0)
       aws-sdk-core (~> 3, >= 3.71.0)
       aws-sigv4 (~> 1.1)
@@ -361,6 +364,7 @@ DEPENDENCIES
   aws-sdk-cognitoidentityprovider
   aws-sdk-rails
   aws-sdk-s3
+  aws-sdk-secretsmanager
   bootsnap
   brakeman
   bundler-audit

--- a/app/services/cognito/auth_user.rb
+++ b/app/services/cognito/auth_user.rb
@@ -58,7 +58,7 @@ module Cognito
     # Performs the call to Cognito. Returns Cognito response.
     def auth_user
       log_action 'Authenticating user'
-      auth_response = COGNITO_CLIENT.initiate_auth(
+      auth_response = client.initiate_auth(
         client_id: ENV.fetch('AWS_COGNITO_CLIENT_ID', 'AWS_COGNITO_CLIENT_ID'),
         auth_flow: 'USER_PASSWORD_AUTH',
         auth_parameters: { 'USERNAME' => username, 'PASSWORD' => password }

--- a/app/services/cognito/client.rb
+++ b/app/services/cognito/client.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+##
+# Module used to wrap communication with Amazon Cognito
+module Cognito
+  ##
+  # Singleton Class used to request Cognito client.
+  class Client
+    include Singleton
+
+    attr_reader :client
+
+    ##
+    # Initializer method for the service.
+    #
+    def initialize
+      @client = load_client
+    end
+
+    ##
+    # Method called when class does not implement the method
+    # Then we try to call Cognito Client if respond to that method
+    def method_missing(method, *args, &block)
+      return client.send(method, *args, &block) if respond_to_missing?(method)
+
+      super
+    rescue Aws::CognitoIdentityProvider::Errors::ResourceNotFoundException,
+           Aws::CognitoIdentityProvider::Errors::UnrecognizedClientException => e
+      Rails.logger.info "Rescue From: #{e.class.name} - rotate credentials"
+      # reload Cognito Client
+      @client = load_client
+      # retry
+      client.send(method, *args, &block)
+    end
+
+    ##
+    # Method which check if Cognito Client respond to the missing method.
+    def respond_to_missing?(method, include_private = false)
+      client.respond_to?(method) || super
+    end
+
+    private
+
+    # Loads AWS Cognito Client
+    def load_client
+      return Aws::CognitoIdentityProvider::Client.new unless cognito_sdk_secret
+
+      Aws::CognitoIdentityProvider::Client.new(credentials: secret_manager_credentials)
+    end
+
+    # Check if COGNITO_SDK_SECRET is set
+    def cognito_sdk_secret
+      ENV['COGNITO_SDK_SECRET']
+    end
+
+    # Loads Credentials from SecretManager
+    def secret_manager_credentials
+      sm_credentials = JSON.parse(
+        secret_manager_client.get_secret_value(secret_id: cognito_sdk_secret).secret_string
+      )
+      Aws::Credentials.new(
+        sm_credentials['awsAccessKeyId'],
+        sm_credentials['awsSecretAccessKey']
+      )
+    end
+
+    # Loads SecretManager Client.
+    def secret_manager_client
+      Aws::SecretsManager::Client.new(
+        region: ENV['AWS_REGION'],
+        credentials: Aws::ECSCredentials.new({ ip_address: '169.254.170.2' })
+      )
+    end
+  end
+end

--- a/app/services/cognito/cognito_base_service.rb
+++ b/app/services/cognito/cognito_base_service.rb
@@ -22,5 +22,11 @@ module Cognito
     def user_pool_id
       ENV['AWS_COGNITO_USER_POOL_ID'].split('/').last
     end
+
+    private
+
+    def client
+      Cognito::Client.instance
+    end
   end
 end

--- a/app/services/cognito/forgot_password/confirm.rb
+++ b/app/services/cognito/forgot_password/confirm.rb
@@ -87,7 +87,7 @@ module Cognito
       # Perform call to AWS Cognito to set a new password.
       def confirm_forgot_password
         log_action 'Confirming forgot password'
-        COGNITO_CLIENT.confirm_forgot_password(
+        client.confirm_forgot_password(
           client_id: ENV['AWS_COGNITO_CLIENT_ID'],
           username: username,
           password: password,

--- a/app/services/cognito/forgot_password/get_user.rb
+++ b/app/services/cognito/forgot_password/get_user.rb
@@ -32,7 +32,7 @@ module Cognito
 
       # Perform the call to Cognito service to get user attributes
       def admin_get_user
-        COGNITO_CLIENT.admin_get_user({ user_pool_id: user_pool_id, username: username })
+        client.admin_get_user({ user_pool_id: user_pool_id, username: username })
       rescue AWS_ERROR::ServiceError
         raise Cognito::CallException.new('', forgot_password_error_path)
       end

--- a/app/services/cognito/forgot_password/reset.rb
+++ b/app/services/cognito/forgot_password/reset.rb
@@ -58,7 +58,7 @@ module Cognito
       # Requests a Cognito service to perform email send with a new temporary password.
       def cognito_call
         log_action 'Forgot password call and email sending'
-        COGNITO_CLIENT.forgot_password(
+        client.forgot_password(
           client_id: ENV['AWS_COGNITO_CLIENT_ID'],
           username: username
         )

--- a/app/services/cognito/forgot_password/update_user.rb
+++ b/app/services/cognito/forgot_password/update_user.rb
@@ -38,7 +38,7 @@ module Cognito
       # Perform the call to Cognito service to update user attributes
       def admin_update_user
         log_action "Updating the password reset rate limit fields to: #{reset_counter}"
-        COGNITO_CLIENT.admin_update_user_attributes(
+        client.admin_update_user_attributes(
           { user_pool_id: user_pool_id, username: username, user_attributes: user_attributes }
         )
         log_successful_call

--- a/app/services/cognito/get_user.rb
+++ b/app/services/cognito/get_user.rb
@@ -51,7 +51,7 @@ module Cognito
     def user_data
       unless defined? @user_data
         log_action 'Getting user'
-        @user_data = COGNITO_CLIENT.get_user(access_token: access_token)
+        @user_data = client.get_user(access_token: access_token)
         log_successful_call
       end
 

--- a/app/services/cognito/respond_to_auth_challenge.rb
+++ b/app/services/cognito/respond_to_auth_challenge.rb
@@ -73,7 +73,7 @@ module Cognito
     # Sets a new user password on Cognito.
     def call_cognito
       log_action 'Respond to auth call'
-      result = COGNITO_CLIENT.respond_to_auth_challenge(
+      result = client.respond_to_auth_challenge(
         challenge_name: 'NEW_PASSWORD_REQUIRED',
         client_id: ENV['AWS_COGNITO_CLIENT_ID'],
         session: user.aws_session,

--- a/config/initializers/cognito_client.rb
+++ b/config/initializers/cognito_client.rb
@@ -1,3 +1,0 @@
-# frozen_string_literal: true
-
-COGNITO_CLIENT = Aws::CognitoIdentityProvider::Client.new

--- a/spec/requests/passwords/send_confirmation_code_spec.rb
+++ b/spec/requests/passwords/send_confirmation_code_spec.rb
@@ -45,7 +45,7 @@ describe 'PasswordsController - POST #send_confirmation_code', type: :request do
 
     context 'when service raises `UserNotFoundException` exception' do
       before do
-        allow(COGNITO_CLIENT).to receive(:forgot_password).and_raise(
+        allow(Cognito::Client.instance).to receive(:forgot_password).and_raise(
           Aws::CognitoIdentityProvider::Errors::UserNotFoundException.new('', '')
         )
         http_request

--- a/spec/requests/sign_in_spec.rb
+++ b/spec/requests/sign_in_spec.rb
@@ -28,7 +28,7 @@ describe 'User singing in', type: :request do
 
     context 'when incorrect credentials given' do
       before do
-        expect(COGNITO_CLIENT).to receive(:initiate_auth)
+        expect(Cognito::Client.instance).to receive(:initiate_auth)
           .and_raise(
             Aws::CognitoIdentityProvider::Errors::NotAuthorizedException.new('', 'error')
           )
@@ -42,7 +42,7 @@ describe 'User singing in', type: :request do
 
     context 'when another error occurs' do
       before do
-        allow(COGNITO_CLIENT).to receive(:initiate_auth)
+        allow(Cognito::Client.instance).to receive(:initiate_auth)
           .and_raise(
             Aws::CognitoIdentityProvider::Errors::InternalErrorException.new('', 'error')
           )

--- a/spec/services/cognito/auth_user_spec.rb
+++ b/spec/services/cognito/auth_user_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Cognito::AuthUser do
 
   context 'with successful call' do
     before do
-      allow(COGNITO_CLIENT).to receive(:initiate_auth).with(
+      allow(Cognito::Client.instance).to receive(:initiate_auth).with(
         client_id: anything,
         auth_flow: 'USER_PASSWORD_AUTH',
         auth_parameters:
@@ -84,7 +84,7 @@ RSpec.describe Cognito::AuthUser do
 
   context 'when call raises exception' do
     before do
-      allow(COGNITO_CLIENT)
+      allow(Cognito::Client.instance)
         .to receive(:initiate_auth)
         .and_raise(
           Aws::CognitoIdentityProvider::Errors::NotAuthorizedException.new('', 'error')

--- a/spec/services/cognito/client_spec.rb
+++ b/spec/services/cognito/client_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Cognito::Client do
+  subject(:service) do
+    Class.new described_class
+  end
+
+  let(:aws_cognito_client) { Aws::CognitoIdentityProvider::Client.new }
+
+  before do
+    allow(Aws::CognitoIdentityProvider::Client).to(
+      receive(:new).and_return(aws_cognito_client)
+    )
+  end
+
+  context 'When cognito client raise ResourceNotFoundException' do
+    before do
+      allow(aws_cognito_client).to(receive(:list_users)).and_raise(
+        Aws::CognitoIdentityProvider::Errors::ResourceNotFoundException.new('', 'error')
+      )
+    end
+
+    it 'retries to call after credentials rotation' do
+      expect(aws_cognito_client).to receive(:list_users).twice
+      begin
+        service.instance.list_users
+      rescue Aws::CognitoIdentityProvider::Errors::ResourceNotFoundException
+        Rails.logger.info 'Servive raises exception'
+      end
+    end
+  end
+
+  context 'When cognito client raise UnrecognizedClientException' do
+    before do
+      allow(aws_cognito_client).to(receive(:list_users)).and_raise(
+        Aws::CognitoIdentityProvider::Errors::UnrecognizedClientException.new('', 'error')
+      )
+    end
+
+    it 'retries to call after credentials rotation' do
+      expect(aws_cognito_client).to receive(:list_users).twice
+      begin
+        service.instance.list_users
+      rescue Aws::CognitoIdentityProvider::Errors::UnrecognizedClientException
+        Rails.logger.info 'Servive raises exception'
+      end
+    end
+  end
+
+  context 'When cognito client raise other exception' do
+    before do
+      allow(aws_cognito_client).to(receive(:list_users)).and_raise(
+        Aws::CognitoIdentityProvider::Errors::UserNotFoundException.new('', 'error')
+      )
+    end
+
+    it 'does not retries the call' do
+      expect(aws_cognito_client).to receive(:list_users).once
+      begin
+        service.instance.list_users
+      rescue Aws::CognitoIdentityProvider::Errors::UserNotFoundException
+        Rails.logger.info 'Servive raises exception'
+      end
+    end
+  end
+
+  context 'When cognito client raise other exception' do
+    let(:users) { %w[user1 user2] }
+
+    before do
+      allow(aws_cognito_client).to(receive(:list_users)).and_return(users)
+    end
+
+    it 'returns the result frotm the AWS' do
+      response = service.instance.list_users
+      expect(response).to equal(users)
+    end
+
+    it 'calls AWS only once' do
+      expect(aws_cognito_client).to receive(:list_users).once
+      service.instance.list_users
+    end
+  end
+end

--- a/spec/services/cognito/forgot_password/confirm_spec.rb
+++ b/spec/services/cognito/forgot_password/confirm_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Cognito::ForgotPassword::Confirm do
   let(:form) { OpenStruct.new(valid?: true) }
 
   before do
-    allow(COGNITO_CLIENT).to receive(:confirm_forgot_password).with(
+    allow(Cognito::Client.instance).to receive(:confirm_forgot_password).with(
       client_id: anything,
       username: username,
       password: password,
@@ -41,7 +41,7 @@ RSpec.describe Cognito::ForgotPassword::Confirm do
     end
 
     it 'calls Cognito' do
-      expect(COGNITO_CLIENT).to receive(:confirm_forgot_password)
+      expect(Cognito::Client.instance).to receive(:confirm_forgot_password)
       service_call
     end
   end
@@ -61,7 +61,7 @@ RSpec.describe Cognito::ForgotPassword::Confirm do
     let(:error) { "User with username '#{username}' was not found" }
 
     before do
-      allow(COGNITO_CLIENT).to receive(:confirm_forgot_password).with(
+      allow(Cognito::Client.instance).to receive(:confirm_forgot_password).with(
         client_id: anything,
         username: username,
         password: password,

--- a/spec/services/cognito/forgot_password/get_user_spec.rb
+++ b/spec/services/cognito/forgot_password/get_user_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Cognito::ForgotPassword::GetUser do
   let(:username) { 'user@example.com' }
 
   before do
-    allow(COGNITO_CLIENT).to receive(:admin_get_user).with(
+    allow(Cognito::Client.instance).to receive(:admin_get_user).with(
       user_pool_id: anything,
       username: username
     ).and_return(true)
@@ -16,7 +16,7 @@ RSpec.describe Cognito::ForgotPassword::GetUser do
 
   context 'with successful call' do
     it 'calls Cognito with proper params and returns true' do
-      expect(COGNITO_CLIENT).to receive(:admin_get_user).with(
+      expect(Cognito::Client.instance).to receive(:admin_get_user).with(
         user_pool_id: anything,
         username: username
       ).and_return(true)
@@ -24,10 +24,10 @@ RSpec.describe Cognito::ForgotPassword::GetUser do
     end
   end
 
-  context 'when `COGNITO_CLIENT.admin_get_user` call fails with proper params' do
+  context 'when `Cognito::Client.instance.admin_get_user` call fails with proper params' do
     context 'and service raises `ServiceError`' do
       before do
-        allow(COGNITO_CLIENT).to receive(:admin_get_user).with(
+        allow(Cognito::Client.instance).to receive(:admin_get_user).with(
           user_pool_id: anything,
           username: username
         ).and_raise(
@@ -42,7 +42,7 @@ RSpec.describe Cognito::ForgotPassword::GetUser do
 
     context 'and service raises `UserNotFoundException`' do
       before do
-        allow(COGNITO_CLIENT).to receive(:admin_get_user).with(
+        allow(Cognito::Client.instance).to receive(:admin_get_user).with(
           user_pool_id: anything,
           username: username
         ).and_raise(

--- a/spec/services/cognito/forgot_password/rate_limit_verification_spec.rb
+++ b/spec/services/cognito/forgot_password/rate_limit_verification_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Cognito::ForgotPassword::RateLimitVerification do
   let(:reset_requested) { nil }
 
   before do
-    allow(COGNITO_CLIENT).to receive(:admin_get_user).with(
+    allow(Cognito::Client.instance).to receive(:admin_get_user).with(
       user_pool_id: anything,
       username: username
     ).and_return(admin_get_user_response)
@@ -67,10 +67,10 @@ RSpec.describe Cognito::ForgotPassword::RateLimitVerification do
     end
   end
 
-  context 'when `COGNITO_CLIENT.admin_get_user` call fails with proper params' do
+  context 'when `Cognito::Client.instance.admin_get_user` call fails with proper params' do
     context 'and service raises `ServiceError`' do
       before do
-        allow(COGNITO_CLIENT).to receive(:admin_get_user).with(
+        allow(Cognito::Client.instance).to receive(:admin_get_user).with(
           user_pool_id: anything,
           username: username
         ).and_raise(
@@ -85,7 +85,7 @@ RSpec.describe Cognito::ForgotPassword::RateLimitVerification do
 
     context 'and service raises `UserNotFoundException`' do
       before do
-        allow(COGNITO_CLIENT).to receive(:admin_get_user).with(
+        allow(Cognito::Client.instance).to receive(:admin_get_user).with(
           user_pool_id: anything,
           username: username
         ).and_raise(

--- a/spec/services/cognito/forgot_password/reset_spec.rb
+++ b/spec/services/cognito/forgot_password/reset_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Cognito::ForgotPassword::Reset do
     allow(Cognito::ForgotPassword::RateLimitVerification).to receive(:call).with(
       username: username
     ).and_return(true)
-    allow(COGNITO_CLIENT).to receive(:forgot_password).with(
+    allow(Cognito::Client.instance).to receive(:forgot_password).with(
       client_id: anything,
       username: username
     ).and_return(cognito_response)
@@ -31,7 +31,7 @@ RSpec.describe Cognito::ForgotPassword::Reset do
     end
 
     it 'calls Cognito' do
-      expect(COGNITO_CLIENT).to receive(:forgot_password)
+      expect(Cognito::Client.instance).to receive(:forgot_password)
       service_call
     end
   end
@@ -53,7 +53,7 @@ RSpec.describe Cognito::ForgotPassword::Reset do
 
     context 'when service raises `ServiceError` exception' do
       before do
-        allow(COGNITO_CLIENT).to receive(:forgot_password).with(
+        allow(Cognito::Client.instance).to receive(:forgot_password).with(
           client_id: anything,
           username: username
         ).and_raise(
@@ -68,7 +68,7 @@ RSpec.describe Cognito::ForgotPassword::Reset do
 
     context 'when service raises `UserNotFoundException` exception' do
       before do
-        allow(COGNITO_CLIENT).to receive(:forgot_password).with(
+        allow(Cognito::Client.instance).to receive(:forgot_password).with(
           client_id: anything,
           username: username
         ).and_raise(
@@ -101,7 +101,7 @@ RSpec.describe Cognito::ForgotPassword::Reset do
 
     context 'when service raises `UserNotFoundException` exception' do
       before do
-        allow(COGNITO_CLIENT).to receive(:forgot_password).with(
+        allow(Cognito::Client.instance).to receive(:forgot_password).with(
           client_id: anything,
           username: username
         ).and_raise(

--- a/spec/services/cognito/forgot_password/update_user_spec.rb
+++ b/spec/services/cognito/forgot_password/update_user_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Cognito::ForgotPassword::UpdateUser do
   end
 
   before do
-    allow(COGNITO_CLIENT).to receive(:admin_update_user_attributes).with(
+    allow(Cognito::Client.instance).to receive(:admin_update_user_attributes).with(
       user_pool_id: anything,
       username: username,
       user_attributes: user_attributes
@@ -38,7 +38,7 @@ RSpec.describe Cognito::ForgotPassword::UpdateUser do
 
   context 'with successful call' do
     it 'calls Cognito with proper params and returns true' do
-      expect(COGNITO_CLIENT).to receive(:admin_update_user_attributes).with(
+      expect(Cognito::Client.instance).to receive(:admin_update_user_attributes).with(
         user_pool_id: anything,
         username: username,
         user_attributes: user_attributes
@@ -47,10 +47,11 @@ RSpec.describe Cognito::ForgotPassword::UpdateUser do
     end
   end
 
-  context 'when `COGNITO_CLIENT.admin_update_user_attributes` call fails with proper params' do
+  context 'when `Cognito::Client.instance.admin_update_user_attributes`
+           call fails with proper params' do
     context 'and service raises `ServiceError`' do
       before do
-        allow(COGNITO_CLIENT).to receive(:admin_update_user_attributes).with(
+        allow(Cognito::Client.instance).to receive(:admin_update_user_attributes).with(
           user_pool_id: anything,
           username: username,
           user_attributes: user_attributes
@@ -66,7 +67,7 @@ RSpec.describe Cognito::ForgotPassword::UpdateUser do
 
     context 'and service raises `UserNotFoundException`' do
       before do
-        allow(COGNITO_CLIENT).to receive(:admin_update_user_attributes).with(
+        allow(Cognito::Client.instance).to receive(:admin_update_user_attributes).with(
           user_pool_id: anything,
           username: username,
           user_attributes: user_attributes

--- a/spec/services/cognito/get_user_spec.rb
+++ b/spec/services/cognito/get_user_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Cognito::GetUser do
   let(:authorized_list_type) { 'green' }
 
   before do
-    allow(COGNITO_CLIENT).to receive(:get_user)
+    allow(Cognito::Client.instance).to receive(:get_user)
       .with(access_token: token)
       .and_return(cognito_response)
   end

--- a/spec/services/cognito/respond_to_auth_spec.rb
+++ b/spec/services/cognito/respond_to_auth_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Cognito::RespondToAuthChallenge do
     allow(Cognito::GetUser).to receive(:call)
       .with(access_token: token, user: user, username: user.username)
       .and_return(cognito_user)
-    allow(COGNITO_CLIENT).to receive(:respond_to_auth_challenge)
+    allow(Cognito::Client.instance).to receive(:respond_to_auth_challenge)
       .with(
         challenge_name: 'NEW_PASSWORD_REQUIRED',
         client_id: anything,
@@ -64,7 +64,7 @@ RSpec.describe Cognito::RespondToAuthChallenge do
     let(:error) { I18n.t('password.errors.complexity') }
 
     before do
-      allow(COGNITO_CLIENT).to receive(:respond_to_auth_challenge).and_raise(
+      allow(Cognito::Client.instance).to receive(:respond_to_auth_challenge).and_raise(
         Aws::CognitoIdentityProvider::Errors::InvalidPasswordException.new('', 'error')
       )
     end
@@ -78,7 +78,7 @@ RSpec.describe Cognito::RespondToAuthChallenge do
     let(:error) { I18n.t('expired_session') }
 
     before do
-      allow(COGNITO_CLIENT).to receive(:respond_to_auth_challenge).and_raise(
+      allow(Cognito::Client.instance).to receive(:respond_to_auth_challenge).and_raise(
         Aws::CognitoIdentityProvider::Errors::UserNotFoundException.new('', 'error')
       )
     end


### PR DESCRIPTION
<!--- When merging branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Jira Card: https://eaflood.atlassian.net/browse/CAZB-1868
Added support for storing Cognito credentials in Secrets Manager. 
We should load it only once and rotate the credentials when invalidated.

## Description
<!--- Describe your changes in detail -->
Added Singleton Client class to which stores the client with loaded credentials and call AWS client.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested if it works with std credentials when ENV COGNITO_SDK_SECRET is not set. 
Tested on AWS in Retrofit web app. 

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes a link to an issue (if apply)
- [x] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/VCC-123/... for new features cards (branched of develop) --->
<!--- - bug/VCC-123/... for bugs (branched of develop) --->
