### PR TITLE
[CAZB-2748] Set Cache-control to no-store to prevent session reload

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -64,7 +64,7 @@ Rails.application.configure do
     # custom
     'Strict-Transport-Security' => 'max-age=31536000',
     'Pragma' => 'no-cache',
-    'Cache-Control' => 'public, s-maxage=31536000, max-age=15552000',
+    'Cache-Control' => 'no-store',
     'Expires' => 1.year.from_now.to_formatted_s(:rfc822).to_s,
     'Feature-Policy' => features.map { |f| "#{f} 'none'" }.join('; ')
   }


### PR DESCRIPTION
Set cache-control header to no-store to prevent disk reload of HTML content after session termination.